### PR TITLE
feat: 기본 entity 생성 및 연관관계 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### properties ###
+application.properties

--- a/src/main/java/merona/nabdbackend/BaseEntity.java
+++ b/src/main/java/merona/nabdbackend/BaseEntity.java
@@ -1,0 +1,26 @@
+package merona.nabdbackend;
+
+import lombok.Getter;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+@DynamicUpdate
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false, name = "create_at")
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "update_at")
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/merona/nabdbackend/board/entity/Board.java
+++ b/src/main/java/merona/nabdbackend/board/entity/Board.java
@@ -1,0 +1,32 @@
+package merona.nabdbackend.board.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import merona.nabdbackend.BaseEntity;
+import merona.nabdbackend.board.enums.State;
+import merona.nabdbackend.user.entity.User;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Board extends BaseEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "board_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+    private String contents;
+
+    @Enumerated(EnumType.STRING)
+    private State state;
+
+    //Address 추가 예정. 객체로 분리할지에 대한 추가 논의
+}

--- a/src/main/java/merona/nabdbackend/board/enums/State.java
+++ b/src/main/java/merona/nabdbackend/board/enums/State.java
@@ -1,0 +1,5 @@
+package merona.nabdbackend.board.enums;
+
+public enum State {
+    REQUEST_WAITING, REQUEST_COMPLETE, REQUEST_ON_GOING
+}

--- a/src/main/java/merona/nabdbackend/user/entity/User.java
+++ b/src/main/java/merona/nabdbackend/user/entity/User.java
@@ -1,0 +1,35 @@
+package merona.nabdbackend.user.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import merona.nabdbackend.BaseEntity;
+import merona.nabdbackend.board.entity.Board;
+import merona.nabdbackend.user.enums.Role;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "user_id")
+    private Long id;
+
+    @OneToMany(mappedBy = "user")
+    private List<Board> boards = new ArrayList<>();
+
+    private String email;
+    private String name;
+    private String password;
+    private String phoneNumber;
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    //Address 추가 예정. 객체로 분리할지에 대한 추가 논의
+
+}

--- a/src/main/java/merona/nabdbackend/user/enums/Role.java
+++ b/src/main/java/merona/nabdbackend/user/enums/Role.java
@@ -1,0 +1,5 @@
+package merona.nabdbackend.user.enums;
+
+public enum Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    #test 용도로 사용
+    url: jdbc:h2:tcp://localhost/~/test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        #show_sql: true
+        format_sql: true
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.type: trace


### PR DESCRIPTION
## 기본 entity 설정
- User
- Board
- BaseEntity
- 연관 관계 설정 완료.
- yml 파일에 공통 사항 저장, 민감 정보는 properties 사용하기 위해 .ignore에 해당 내용 추가함