### PR TITLE
feature: JWT 이용한 로그인 인증 및 토큰 재발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/merona/nabdbackend/auth/CustomUserDetailService.java
+++ b/src/main/java/merona/nabdbackend/auth/CustomUserDetailService.java
@@ -1,0 +1,25 @@
+package merona.nabdbackend.auth;
+
+import lombok.RequiredArgsConstructor;
+import merona.nabdbackend.exception.FindUserWithUsernameNotFoundException;
+import merona.nabdbackend.user.entity.User;
+import merona.nabdbackend.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomUserDetailService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findUserByEmail(username).orElseThrow(FindUserWithUsernameNotFoundException::new);
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/merona/nabdbackend/auth/CustomUserDetails.java
+++ b/src/main/java/merona/nabdbackend/auth/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package merona.nabdbackend.auth;
+
+import merona.nabdbackend.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        String roles = user.getRole().toString();
+        for (String role : roles.split(",")) {
+            authorities.add(() -> role);
+        }
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/merona/nabdbackend/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/merona/nabdbackend/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package merona.nabdbackend.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException{
+        // 1. Request Header 에서 JWT 토큰 추출
+        String token = resolveToken((HttpServletRequest) request);
+
+        // 2. validateToken 으로 토큰 유효성 검사
+        if (token != null && jwtProvider.validateToken(token)) {
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext 에 저장
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+    private String resolveToken(HttpServletRequest request){
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/merona/nabdbackend/auth/JwtProvider.java
+++ b/src/main/java/merona/nabdbackend/auth/JwtProvider.java
@@ -1,0 +1,112 @@
+package merona.nabdbackend.auth;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class JwtProvider {
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 4 * 60 * 60 * 1000L; //4시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 14 * 24 * 60 * 60 * 1000L; //2주
+
+    private final Key key;
+
+    public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenDto generateToken(Authentication authentication) {
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
+    public Authentication getAuthentication(String accessToken) {
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 리턴
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 정보를 검증하는 메서드
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/merona/nabdbackend/auth/SecurityConfig.java
+++ b/src/main/java/merona/nabdbackend/auth/SecurityConfig.java
@@ -6,12 +6,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtProvider jwtProvider;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception{
         return httpSecurity
@@ -22,10 +26,15 @@ public class SecurityConfig {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/user/**").permitAll()
-              //  .antMatchers("/admin/**").access("hasRole('ROLE_ADMIN')")
+                .antMatchers("/admin/**").access("hasRole('ROLE_ADMIN')")
                 .anyRequest().permitAll()
                 .and()
-              //  .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/merona/nabdbackend/auth/TokenDto.java
+++ b/src/main/java/merona/nabdbackend/auth/TokenDto.java
@@ -1,0 +1,15 @@
+package merona.nabdbackend.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class TokenDto {
+    //grantType은 JWT 대한 인증 타입
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/merona/nabdbackend/auth/TokenRequestDto.java
+++ b/src/main/java/merona/nabdbackend/auth/TokenRequestDto.java
@@ -1,0 +1,11 @@
+package merona.nabdbackend.auth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRequestDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/merona/nabdbackend/auth/token/RefreshToken.java
+++ b/src/main/java/merona/nabdbackend/auth/token/RefreshToken.java
@@ -1,0 +1,35 @@
+package merona.nabdbackend.auth.token;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@NoArgsConstructor
+@Table(name = "refresh_token")
+@Entity
+public class RefreshToken {
+    @Id
+    @Column(name = "refresh_token_key")
+    private String key;
+
+    @Column(name = "refresh_token_value")
+    private String value;
+
+    @Builder
+    public RefreshToken(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public RefreshToken updateValue(String token) {
+        this.value = token;
+        return this;
+    }
+
+}

--- a/src/main/java/merona/nabdbackend/auth/token/RefreshTokenRepository.java
+++ b/src/main/java/merona/nabdbackend/auth/token/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package merona.nabdbackend.auth.token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByKey(String key);
+}

--- a/src/main/java/merona/nabdbackend/exception/FindUserWithUsernameNotFoundException.java
+++ b/src/main/java/merona/nabdbackend/exception/FindUserWithUsernameNotFoundException.java
@@ -1,0 +1,7 @@
+package merona.nabdbackend.exception;
+
+public class FindUserWithUsernameNotFoundException extends RuntimeException{
+    public FindUserWithUsernameNotFoundException() {
+        super("해당 유저를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/merona/nabdbackend/user/controller/UserController.java
+++ b/src/main/java/merona/nabdbackend/user/controller/UserController.java
@@ -2,6 +2,9 @@ package merona.nabdbackend.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import merona.nabdbackend.auth.TokenDto;
+import merona.nabdbackend.auth.TokenRequestDto;
+import merona.nabdbackend.user.dto.LoginRequestDto;
 import merona.nabdbackend.user.dto.SignUpRequestDto;
 import merona.nabdbackend.user.service.UserService;
 import org.springframework.http.ResponseEntity;
@@ -22,5 +25,16 @@ public class UserController {
         log.info("TEST");
         String email = userService.signUp(requestDto);
         return ResponseEntity.ok().body(email);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDto> login(@RequestBody LoginRequestDto dto) {
+        TokenDto tokenDto = userService.login(dto);
+        return ResponseEntity.ok().body(tokenDto);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissue(@RequestBody TokenRequestDto tokenRequestDto) {
+        return ResponseEntity.ok(userService.reissue(tokenRequestDto));
     }
 }

--- a/src/main/java/merona/nabdbackend/user/dto/LoginRequestDto.java
+++ b/src/main/java/merona/nabdbackend/user/dto/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package merona.nabdbackend.user.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequestDto {
+    private String email;
+    private String password;
+}

--- a/src/main/java/merona/nabdbackend/user/dto/SignUpRequestDto.java
+++ b/src/main/java/merona/nabdbackend/user/dto/SignUpRequestDto.java
@@ -11,6 +11,6 @@ public class SignUpRequestDto {
     private String phoneNumber;
 
     public User userFromDto() {
-        return new User(email, password, name, phoneNumber);
+        return new User(email, name, password, phoneNumber);
     }
 }

--- a/src/main/java/merona/nabdbackend/user/service/UserService.java
+++ b/src/main/java/merona/nabdbackend/user/service/UserService.java
@@ -1,9 +1,16 @@
 package merona.nabdbackend.user.service;
 
 import lombok.RequiredArgsConstructor;
+import merona.nabdbackend.auth.*;
+import merona.nabdbackend.auth.token.RefreshToken;
+import merona.nabdbackend.auth.token.RefreshTokenRepository;
+import merona.nabdbackend.user.dto.LoginRequestDto;
 import merona.nabdbackend.user.dto.SignUpRequestDto;
 import merona.nabdbackend.user.entity.User;
 import merona.nabdbackend.user.repository.UserRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +21,13 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional
 public class UserService {
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    //private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public String signUp(SignUpRequestDto requestDto) {
         Optional<User> userByEmail = userRepository.findUserByEmail(requestDto.getEmail());
         if (userByEmail.isPresent()) {
@@ -28,6 +40,56 @@ public class UserService {
         userRepository.save(user);
 
         return user.getEmail();
+    }
+
+    @Transactional
+    public TokenDto login(LoginRequestDto dto) {
+        // 1. Login ID/PW 를 기반으로 AuthenticationToken 생성
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(dto.getEmail(), dto.getPassword());
+
+        // 2. 실제로 검증 (사용자 비밀번호 체크) 이 이루어지는 부분
+        //    authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // 3. 인증 정보를 기반으로 JWT 생성
+        TokenDto tokenDto = jwtProvider.generateToken(authentication);
+
+        // 4. RefreshToken 저장
+        RefreshToken refreshToken = RefreshToken.builder()
+                .key(authentication.getName())
+                .value(tokenDto.getRefreshToken())
+                .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return tokenDto;
+    }
+
+    @Transactional
+    public TokenDto reissue(TokenRequestDto tokenRequestDto){
+        // 1. Refresh Token 검증
+        if (!jwtProvider.validateToken(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("Refresh Token 이 유효하지 않습니다.");
+        }
+        // 2. Access Token 에서 Member ID 가져오기
+        Authentication authentication = jwtProvider.getAuthentication(tokenRequestDto.getAccessToken());
+
+        // 3. 저장소에서 Member ID 를 기반으로 Refresh Token 값 가져옴
+        RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName())
+                .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다."));
+
+        // 4. Refresh Token 일치하는지 검사
+        if (!refreshToken.getValue().equals(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
+        }
+
+        // 5. 새로운 토큰 생성
+        TokenDto tokenDto = jwtProvider.generateToken(authentication);
+
+        // 6. 저장소 정보 업데이트
+        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
+        refreshTokenRepository.save(newRefreshToken);
+
+        return tokenDto;
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,6 @@ spring:
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace
+
+jwt:
+  secret: VlwEyVBsYt9V7zq57TejMnVUyzblYcfPQye08f7MGVA9XkHa


### PR DESCRIPTION
## 🚀작업 내용
- JWT 이용한 로그인 기능 구현
- 토큰 재발행 기능 추가
- 테스트용 jwt 임시키 추가
- 회원가입시 이름과 비밀번호가 바뀌는 버그 수정
- Security Config 설정 추가

## 🚧논의 사항
- 게시글 기능 만들 때 인증 정보 가져오는 부분, 지금 올리는 PR확인하고 설명 필요한 부분 있으면 말해주세요.
- 지도 기능 좌표랑 주소를 한 객체에 넣어서 만들려고 하는데 다른 의견 있으면 말씀해주세요.
